### PR TITLE
Fix skipped configuration properties due to Boolean vs. boolean bug.

### DIFF
--- a/bonecp/src/main/java/com/jolbox/bonecp/BoneCPConfig.java
+++ b/bonecp/src/main/java/com/jolbox/bonecp/BoneCPConfig.java
@@ -135,9 +135,9 @@ public class BoneCPConfig implements BoneCPConfigMBean, Cloneable, Serializable 
 	/** If true, keep track of some statistics. */
 	private boolean statisticsEnabled;
 	/** The default auto-commit state of created connections. */
-	private Boolean defaultAutoCommit;
+	private boolean defaultAutoCommit;
 	/** The default read-only state of created connections. */
-	private Boolean defaultReadOnly;
+	private boolean defaultReadOnly;
 	/** The default transaction isolation state of created connections. */
 	private String defaultTransactionIsolation;
 	/** The default catalog state of created connections. */
@@ -1206,7 +1206,7 @@ public class BoneCPConfig implements BoneCPConfigMBean, Cloneable, Serializable 
 	 * Returns the defaultAutoCommit field.
 	 * @return defaultAutoCommit
 	 */
-	public Boolean getDefaultAutoCommit() {
+	public boolean getDefaultAutoCommit() {
 		return this.defaultAutoCommit;
 	}
 
@@ -1214,7 +1214,7 @@ public class BoneCPConfig implements BoneCPConfigMBean, Cloneable, Serializable 
 	 * Sets the defaultAutoCommit setting for newly created connections. If not set, use driver default.
 	 * @param defaultAutoCommit the defaultAutoCommit to set
 	 */
-	public void setDefaultAutoCommit(Boolean defaultAutoCommit) {
+	public void setDefaultAutoCommit(boolean defaultAutoCommit) {
 		this.defaultAutoCommit = defaultAutoCommit;
 	}
 
@@ -1222,7 +1222,7 @@ public class BoneCPConfig implements BoneCPConfigMBean, Cloneable, Serializable 
 	 * Returns the defaultReadOnly field.
 	 * @return defaultReadOnly
 	 */
-	public Boolean getDefaultReadOnly() {
+	public boolean getDefaultReadOnly() {
 		return this.defaultReadOnly;
 	}
 
@@ -1230,7 +1230,7 @@ public class BoneCPConfig implements BoneCPConfigMBean, Cloneable, Serializable 
 	 * Sets the defaultReadOnly setting for newly created connections. If not set, use driver default.
 	 * @param defaultReadOnly the defaultReadOnly to set
 	 */
-	public void setDefaultReadOnly(Boolean defaultReadOnly) {
+	public void setDefaultReadOnly(boolean defaultReadOnly) {
 		this.defaultReadOnly = defaultReadOnly;
 	}
 


### PR DESCRIPTION
The properties 'defaultAutoCommit' and 'defaultReadOnly' in
BoneCPConfig were previously of type Boolean (as opposed to boolean
used for all the other options) and since the code responsable for
reading the configuration file entries was testing for equality to
boolean.class (which is not equal to Boolean.class) these configuration
optiones were simply skipped / ignored.

Fixed this by changing the type of the two properties to boolean. An
alternative fix could be to change the equality tests in setProperties
in class BoneCPConfig to test for equality both to Boolean.class and
boolean.class (same should be considered for the other cases involving
long and int types in the same method).
