### PR TITLE
Patch for https://bugs.launchpad.net/bonecp/+bug/999114

### DIFF
--- a/bonecp/src/main/java/com/jolbox/bonecp/BoneCP.java
+++ b/bonecp/src/main/java/com/jolbox/bonecp/BoneCP.java
@@ -626,6 +626,10 @@ public class BoneCP implements Serializable, Closeable {
 		if (connectionHandle.isExpired() || (!this.poolShuttingDown && connectionHandle.isPossiblyBroken()
 				&& !isConnectionHandleAlive(connectionHandle))){
 
+            if (connectionHandle.isExpired()) {
+                connectionHandle.internalClose();
+            }
+
 			ConnectionPartition connectionPartition = connectionHandle.getOriginatingPartition();
 			postDestroyConnection(connectionHandle);
 

--- a/bonecp/src/test/java/com/jolbox/bonecp/TestBoneCP.java
+++ b/bonecp/src/test/java/com/jolbox/bonecp/TestBoneCP.java
@@ -821,8 +821,6 @@ public class TestBoneCP {
 	 */
 	@Test
 	public void testInternalReleaseConnectionWhereConnectionIsBroken() throws InterruptedException, SQLException {
-
-
 		// Test case where connection is broken
 		reset(mockConnection,mockPartition, mockConnectionHandles);
 		expect(mockConnection.isPossiblyBroken()).andReturn(true).once();
@@ -844,10 +842,37 @@ public class TestBoneCP {
 		replay(mockPartition, mockConnection);
 		testClass.internalReleaseConnection(mockConnection);
 		verify(mockPartition, mockConnection);
-
 	}
 
-	/**
+    /**
+     * Test method for {@link com.jolbox.bonecp.BoneCP#internalReleaseConnection(ConnectionHandle)}.
+     *
+     * @throws InterruptedException
+     * @throws SQLException
+     */
+    @Test
+    public void testInternalReleaseConnectionWhereConnectionIsExpired() throws InterruptedException, SQLException {
+        // Test case where connection is expired
+        reset(mockConnection, mockPartition, mockConnectionHandles);
+
+        Connection mockRealConnection = createNiceMock(Connection.class);
+        expect(mockConnection.getInternalConnection()).andReturn(mockRealConnection).anyTimes();
+
+        // return a partition
+        expect(mockConnection.getOriginatingPartition()).andReturn(mockPartition).anyTimes();
+        // break out from this method, we're not interested in it
+        expect(mockPartition.isUnableToCreateMoreTransactions()).andReturn(true).once();
+
+        expect(mockConnection.isExpired()).andReturn(true).anyTimes();
+        mockConnection.internalClose();
+        expectLastCall();
+
+        replay(mockPartition, mockConnection, mockRealConnection);
+        testClass.internalReleaseConnection(mockConnection);
+        verify(mockPartition, mockConnection, mockRealConnection);
+    }
+
+    /**
 	 * Test method for {@link com.jolbox.bonecp.BoneCP#putConnectionBackInPartition(com.jolbox.bonecp.ConnectionHandle)}.
 	 * @throws InterruptedException 
 	 * @throws SQLException 


### PR DESCRIPTION
This is a fix for the following bug:

A connection is expired and therefore gets released (in BoneCP.internalReleaseConnection()). However, the connection does not get closed. 

For more details, see https://bugs.launchpad.net/bonecp/+bug/999114
