### PR TITLE
When loadining resources from ClassLoader, leading / doesn't work.

### DIFF
--- a/bonecp/src/main/java/com/jolbox/bonecp/BoneCPConfig.java
+++ b/bonecp/src/main/java/com/jolbox/bonecp/BoneCPConfig.java
@@ -1339,9 +1339,9 @@ public class BoneCPConfig implements BoneCPConfigMBean, Cloneable, Serializable 
 	 */
 	public BoneCPConfig(){
 		// try to load the default config file, if available from somewhere in the classpath
-		loadProperties("/bonecp-default-config.xml");
+		loadProperties("bonecp-default-config.xml");
 		// try to override with app specific config, if available
-		loadProperties("/bonecp-config.xml");
+		loadProperties("bonecp-config.xml");
 	}
 
 	/** Creates a new config using the given properties.


### PR DESCRIPTION
Fixed resource name: search resources from class loader root without leading slash.
