### PR TITLE
Fixed an issue with ConnetionHandle.close() resulting in a connection leak.

### DIFF
--- a/bonecp/src/main/java/com/jolbox/bonecp/ConnectionHandle.java
+++ b/bonecp/src/main/java/com/jolbox/bonecp/ConnectionHandle.java
@@ -197,7 +197,15 @@ public class ConnectionHandle implements Connection,Serializable{
 	 *             on error
 	 */
 	protected ConnectionHandle(Connection connection, BoneCP pool, boolean recreating) throws SQLException {
+		this(connection, pool, recreating, null);
+	}
+	
+	protected ConnectionHandle(Connection connection, BoneCP pool, boolean recreating, ConnectionPartition copyFromPartition) throws SQLException {
 		boolean newConnection = connection == null;
+
+		if (copyFromPartition!=null)
+			this.originatingPartition = copyFromPartition;
+		
 		this.pool = pool;
 		this.connectionHook = pool.getConfig().getConnectionHook();
 
@@ -273,7 +281,7 @@ public class ConnectionHandle implements Connection,Serializable{
 	 * @throws SQLException
 	 */
 	public ConnectionHandle recreateConnectionHandle() throws SQLException{
-		ConnectionHandle handle = new ConnectionHandle(this.connection, this.pool, true);
+		ConnectionHandle handle = new ConnectionHandle(this.connection, this.pool, true, this.originatingPartition);
 		handle.originatingPartition = this.originatingPartition;
 		handle.connectionCreationTimeInMs = this.connectionCreationTimeInMs;
 		handle.connectionLastResetInMs = this.connectionLastResetInMs;


### PR DESCRIPTION
In the original code,

 ConnectionHandle handle = this.recreateConnectionHandle();
 this.pool.connectionStrategy.cleanupConnection(this, handle);
 this.pool.releaseConnection(handle);

recreateConnectionHandle can throw an exception on setAutoCommit in the constructor. As a result, the two lines below are not executed and the connection is not released. 
