### PR TITLE
Fixed connection leak, better than pull request #11

### DIFF
--- a/bonecp/src/main/java/com/jolbox/bonecp/ConnectionHandle.java
+++ b/bonecp/src/main/java/com/jolbox/bonecp/ConnectionHandle.java
@@ -249,7 +249,9 @@ public class ConnectionHandle implements Connection,Serializable{
 			// this kick-starts recording everything
 			this.connection = MemorizeTransactionProxy.memorize(this.connection, this);
 		}
-
+		if(!newConnection && !connection.getAutoCommit() && !connection.isClosed()){
+			connection.rollback();
+		}
 		if (this.defaultAutoCommit != null){
 			setAutoCommit(this.defaultAutoCommit);
 		}


### PR DESCRIPTION
Prevent org.postgresql.util.PSQLException: Cannot change transaction read-only property in the middle of a transaction

when release connection to pool,bonecp will call setReadonly on connection,if there is a transaction and is not ended,postgresql(maybe other database) will throw exception.
org.postgresql.util.PSQLException: Cannot change transaction read-only property in the middle of a transaction

the resolution is try rollback to end transaction on the reuse connection
