### PR TITLE
fixed transaction memorization, which was slow and broken

### DIFF
--- a/bonecp/src/main/java/com/jolbox/bonecp/ConnectionHandle.java
+++ b/bonecp/src/main/java/com/jolbox/bonecp/ConnectionHandle.java
@@ -256,8 +256,10 @@ public class ConnectionHandle implements Connection,Serializable{
 		if (this.pool.getConfig().isTransactionRecoveryEnabled()){
 			this.replayLog = new ArrayList<ReplayLog>(30);
 			this.recoveryResult = new TransactionRecoveryResult();
-			// this kick-starts recording everything
-			this.connection = MemorizeTransactionProxy.memorize(this.connection, this);
+			if(!recreating){
+				// this kick-starts recording everything; which is not needed on recreation
+				this.connection = MemorizeTransactionProxy.memorize(this.connection, this);
+			}
 		}
 		if(!newConnection && !connection.getAutoCommit() && !connection.isClosed()){
 			connection.rollback();

--- a/bonecp/src/main/java/com/jolbox/bonecp/MemorizeTransactionProxy.java
+++ b/bonecp/src/main/java/com/jolbox/bonecp/MemorizeTransactionProxy.java
@@ -228,6 +228,9 @@ public class MemorizeTransactionProxy implements InvocationHandler {
 
 			}
 
+		}else{
+			//prevent NPE that can occur on calls to hashCode and getAutoCommit when handle is null
+			result = method.invoke(this.target, args);
 		}
 		return result; // normal state
 	}


### PR DESCRIPTION
- fixed NPE on transaction memorization when handle is null
- fixed performance problem with transaction memorization caused by handle recreation always wrapping proxied connection in a new proxy
