### PR TITLE
Set default auto-commit to true in default configuration

### DIFF
--- a/bonecp/src/main/resources/bonecp-default-config.xml
+++ b/bonecp/src/main/resources/bonecp-default-config.xml
@@ -178,7 +178,7 @@
 
 		<!-- Sets the defaultAutoCommit setting for newly created connections. If not set, use driver 
 		     default. -->
-		<property name="defaultAutoCommit">false</property>
+		<property name="defaultAutoCommit">true</property>
 
 		<!-- Sets the defaultReadOnly setting for newly created connections. If not set, use driver 
 		     default. -->


### PR DESCRIPTION
f5de0b3f02d3177561303d9fee1d3b5dbead440b recently changed the default in the field initializer, however the default configuration in bonecp-default-config.xml resets default auto-commit back to false. Thus f5de0b3f02d3177561303d9fee1d3b5dbead440b did not have the intended effect.
