### PR TITLE
Removed LGPL license text from CustomThreadFactory

### DIFF
--- a/bonecp/src/main/java/com/jolbox/bonecp/CustomThreadFactory.java
+++ b/bonecp/src/main/java/com/jolbox/bonecp/CustomThreadFactory.java
@@ -14,26 +14,6 @@
  *    limitations under the License.
  */
 
-/*
-
-Copyright 2009 Wallace Wadge
-
-This file is part of BoneCP.
-
-BoneCP is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-BoneCP is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with BoneCP.  If not, see <http://www.gnu.org/licenses/>.
-*/
-
 package com.jolbox.bonecp;
 
 import java.lang.Thread.UncaughtExceptionHandler;


### PR DESCRIPTION
CustomThreadFactory had _two_ licenses in it: Apache 2.0 at the top, and LGPL next. It was the only file in BoneCP that has this text, so I assume it's there in error. Most likely this bit of LGPL text was missed when the project was moved over to the Apache license.

(This is an important change because the existence of that LGPL text blocks me from using BoneCP in my project.)
