### PR TITLE
Fix copying of configuration during initialization

### DIFF
--- a/bonecp/src/main/java/com/jolbox/bonecp/BoneCP.java
+++ b/bonecp/src/main/java/com/jolbox/bonecp/BoneCP.java
@@ -395,68 +395,67 @@ public class BoneCP implements Serializable, Closeable {
 		}
 		this.config.sanitize();
 
-		this.statisticsEnabled = config.isStatisticsEnabled();
-		this.closeConnectionWatchTimeoutInMs = config.getCloseConnectionWatchTimeoutInMs();
-		this.poolAvailabilityThreshold = config.getPoolAvailabilityThreshold();
-		this.connectionTimeoutInMs = config.getConnectionTimeoutInMs();
+		this.statisticsEnabled = this.config.isStatisticsEnabled();
+		this.closeConnectionWatchTimeoutInMs = this.config.getCloseConnectionWatchTimeoutInMs();
+		this.poolAvailabilityThreshold = this.config.getPoolAvailabilityThreshold();
+		this.connectionTimeoutInMs = this.config.getConnectionTimeoutInMs();
 
 		if (this.connectionTimeoutInMs == 0){
 			this.connectionTimeoutInMs = Long.MAX_VALUE;
 		}
-		this.nullOnConnectionTimeout = config.isNullOnConnectionTimeout();
-		this.resetConnectionOnClose = config.isResetConnectionOnClose();
-		this.clientInfo = jvmMajorVersion > 5  ? config.getClientInfo() : null;
+		this.nullOnConnectionTimeout = this.config.isNullOnConnectionTimeout();
+		this.resetConnectionOnClose = this.config.isResetConnectionOnClose();
+		this.clientInfo = jvmMajorVersion > 5  ? this.config.getClientInfo() : null;
 		AcquireFailConfig acquireConfig = new AcquireFailConfig();
 		acquireConfig.setAcquireRetryAttempts(new AtomicInteger(0));
 		acquireConfig.setAcquireRetryDelayInMs(0);
 		acquireConfig.setLogMessage("Failed to obtain initial connection");
 
-		if (!config.isLazyInit()){
+		if (!this.config.isLazyInit()){
 			try{
 				Connection sanityConnection = obtainRawInternalConnection();
 				sanityConnection.close();
 			} catch (Exception e){
-				if (config.getConnectionHook() != null){
-					config.getConnectionHook().onAcquireFail(e, acquireConfig);
+				if (this.config.getConnectionHook() != null){
+					this.config.getConnectionHook().onAcquireFail(e, acquireConfig);
 				}
-				throw PoolUtil.generateSQLException(String.format(ERROR_TEST_CONNECTION, config.getJdbcUrl(), config.getUsername(), PoolUtil.stringifyException(e)), e);
+				throw PoolUtil.generateSQLException(String.format(ERROR_TEST_CONNECTION, this.config.getJdbcUrl(), this.config.getUsername(), PoolUtil.stringifyException(e)), e);
 
 			}
 		}
-		if (!config.isDisableConnectionTracking()){
+		if (!this.config.isDisableConnectionTracking()){
 			this.finalizableRefQueue = new FinalizableReferenceQueue();
 		}
 
 		this.asyncExecutor = MoreExecutors.listeningDecorator(Executors.newCachedThreadPool());
 
-		this.config = config;
-		this.partitions = new ConnectionPartition[config.getPartitionCount()];
+		this.partitions = new ConnectionPartition[this.config.getPartitionCount()];
 		String suffix = "";
 
-		if (config.getPoolName()!=null) {
-			suffix="-"+config.getPoolName();
+		if (this.config.getPoolName()!=null) {
+			suffix="-"+this.config.getPoolName();
 		}
 
 
-		this.keepAliveScheduler =  Executors.newScheduledThreadPool(config.getPartitionCount(), new CustomThreadFactory("BoneCP-keep-alive-scheduler"+suffix, true));
-		this.maxAliveScheduler =  Executors.newScheduledThreadPool(config.getPartitionCount(), new CustomThreadFactory("BoneCP-max-alive-scheduler"+suffix, true));
-		this.connectionsScheduler =  Executors.newFixedThreadPool(config.getPartitionCount(), new CustomThreadFactory("BoneCP-pool-watch-thread"+suffix, true));
+		this.keepAliveScheduler =  Executors.newScheduledThreadPool(this.config.getPartitionCount(), new CustomThreadFactory("BoneCP-keep-alive-scheduler"+suffix, true));
+		this.maxAliveScheduler =  Executors.newScheduledThreadPool(this.config.getPartitionCount(), new CustomThreadFactory("BoneCP-max-alive-scheduler"+suffix, true));
+		this.connectionsScheduler =  Executors.newFixedThreadPool(this.config.getPartitionCount(), new CustomThreadFactory("BoneCP-pool-watch-thread"+suffix, true));
 
-		this.partitionCount = config.getPartitionCount();
-		this.closeConnectionWatch = config.isCloseConnectionWatch();
-		this.cachedPoolStrategy = config.getPoolStrategy() != null && config.getPoolStrategy().equalsIgnoreCase("CACHED");
+		this.partitionCount = this.config.getPartitionCount();
+		this.closeConnectionWatch = this.config.isCloseConnectionWatch();
+		this.cachedPoolStrategy = this.config.getPoolStrategy() != null && this.config.getPoolStrategy().equalsIgnoreCase("CACHED");
 		if (this.cachedPoolStrategy){
 			this.connectionStrategy = new CachedConnectionStrategy(this, new DefaultConnectionStrategy(this));
 		} else {
 			this.connectionStrategy = new DefaultConnectionStrategy(this);
 		}
-		boolean queueLIFO = config.getServiceOrder() != null && config.getServiceOrder().equalsIgnoreCase("LIFO");
+		boolean queueLIFO = this.config.getServiceOrder() != null && this.config.getServiceOrder().equalsIgnoreCase("LIFO");
 		if (this.closeConnectionWatch){
 			logger.warn(THREAD_CLOSE_CONNECTION_WARNING);
 			this.closeConnectionExecutor =  Executors.newCachedThreadPool(new CustomThreadFactory("BoneCP-connection-watch-thread"+suffix, true));
 
 		}
-		for (int p=0; p < config.getPartitionCount(); p++){
+		for (int p=0; p < this.config.getPartitionCount(); p++){
 
 			ConnectionPartition connectionPartition = new ConnectionPartition(this);
 			this.partitions[p]=connectionPartition;
@@ -464,33 +463,33 @@ public class BoneCP implements Serializable, Closeable {
 
 			this.partitions[p].setFreeConnections(connectionHandles);
 
-			if (!config.isLazyInit()){
-				for (int i=0; i < config.getMinConnectionsPerPartition(); i++){
+			if (!this.config.isLazyInit()){
+				for (int i=0; i < this.config.getMinConnectionsPerPartition(); i++){
 					this.partitions[p].addFreeConnection(new ConnectionHandle(null, this.partitions[p], this, false));
 				}
 
 			}
 
 
-			if (config.getIdleConnectionTestPeriod(TimeUnit.SECONDS) > 0 || config.getIdleMaxAge(TimeUnit.SECONDS) > 0){
+			if (this.config.getIdleConnectionTestPeriod(TimeUnit.SECONDS) > 0 || this.config.getIdleMaxAge(TimeUnit.SECONDS) > 0){
 
-				final Runnable connectionTester = new ConnectionTesterThread(connectionPartition, this.keepAliveScheduler, this, config.getIdleMaxAge(TimeUnit.MILLISECONDS), config.getIdleConnectionTestPeriod(TimeUnit.MILLISECONDS), queueLIFO);
-				long delayInSeconds = config.getIdleConnectionTestPeriod(TimeUnit.SECONDS);
+				final Runnable connectionTester = new ConnectionTesterThread(connectionPartition, this.keepAliveScheduler, this, this.config.getIdleMaxAge(TimeUnit.MILLISECONDS), this.config.getIdleConnectionTestPeriod(TimeUnit.MILLISECONDS), queueLIFO);
+				long delayInSeconds = this.config.getIdleConnectionTestPeriod(TimeUnit.SECONDS);
 				if (delayInSeconds == 0L){
-					delayInSeconds = config.getIdleMaxAge(TimeUnit.SECONDS);
+					delayInSeconds = this.config.getIdleMaxAge(TimeUnit.SECONDS);
 				}
-				if (config.getIdleMaxAge(TimeUnit.SECONDS) < delayInSeconds
-						&& config.getIdleConnectionTestPeriod(TimeUnit.SECONDS) != 0 
-						&& config.getIdleMaxAge(TimeUnit.SECONDS) != 0){
-					delayInSeconds = config.getIdleMaxAge(TimeUnit.SECONDS);
+				if (this.config.getIdleMaxAge(TimeUnit.SECONDS) < delayInSeconds
+						&& this.config.getIdleConnectionTestPeriod(TimeUnit.SECONDS) != 0
+						&& this.config.getIdleMaxAge(TimeUnit.SECONDS) != 0){
+					delayInSeconds = this.config.getIdleMaxAge(TimeUnit.SECONDS);
 				}
 				this.keepAliveScheduler.schedule(connectionTester, delayInSeconds, TimeUnit.SECONDS);
 			}
 
 
-			if (config.getMaxConnectionAgeInSeconds() > 0){
-				final Runnable connectionMaxAgeTester = new ConnectionMaxAgeThread(connectionPartition, this.maxAliveScheduler, this, config.getMaxConnectionAge(TimeUnit.MILLISECONDS), queueLIFO);
-				this.maxAliveScheduler.schedule(connectionMaxAgeTester, config.getMaxConnectionAgeInSeconds(), TimeUnit.SECONDS);
+			if (this.config.getMaxConnectionAgeInSeconds() > 0){
+				final Runnable connectionMaxAgeTester = new ConnectionMaxAgeThread(connectionPartition, this.maxAliveScheduler, this, this.config.getMaxConnectionAge(TimeUnit.MILLISECONDS), queueLIFO);
+				this.maxAliveScheduler.schedule(connectionMaxAgeTester, this.config.getMaxConnectionAgeInSeconds(), TimeUnit.SECONDS);
 			}
 			// watch this partition for low no of threads
 			this.connectionsScheduler.execute(new PoolWatchThread(connectionPartition, this));


### PR DESCRIPTION
During initialization, the configuration object is cloned. The clone
is subsequently sanitized, which among other things parses the
default transaction level. However subsequently the original
unsanitized config is used to extract configuration values, followed
by the clone being discarded and replaced by the original.

One consequence of the above problem is that configuring
defaultTransactionIsolation in bonecp-config.xml has no effect,
as the value is parsed in the sanitize method and the result is
subsequently discarded.

This patch fixes the problem by consistently using the clone after
it is created.
