### PR TITLE
improve scheduling of check tasks

### DIFF
--- a/bonecp/src/main/java/com/jolbox/bonecp/ConnectionMaxAgeThread.java
+++ b/bonecp/src/main/java/com/jolbox/bonecp/ConnectionMaxAgeThread.java
@@ -17,8 +17,6 @@
 
 package com.jolbox.bonecp;
 
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,8 +32,6 @@ public class ConnectionMaxAgeThread implements Runnable {
 	private long maxAgeInMs;
 	/** Partition being handled. */
 	private ConnectionPartition partition;
-	/** Scheduler handle. **/
-	private ScheduledExecutorService scheduler;
 	/** Handle to connection pool. */
 	private BoneCP pool;
 	/** If true, we're operating in a LIFO fashion. */ 
@@ -50,10 +46,9 @@ public class ConnectionMaxAgeThread implements Runnable {
 	 * @param maxAgeInMs Threads older than this are killed off 
 	 * @param lifoMode if true, we're running under a lifo fashion.
 	 */
-	protected ConnectionMaxAgeThread(ConnectionPartition connectionPartition, ScheduledExecutorService scheduler, 
+	protected ConnectionMaxAgeThread(ConnectionPartition connectionPartition,  
 			BoneCP pool, long maxAgeInMs, boolean lifoMode){
 		this.partition = connectionPartition;
-		this.scheduler = scheduler;
 		this.maxAgeInMs = maxAgeInMs;
 		this.pool = pool;
 		this.lifoMode = lifoMode;
@@ -102,18 +97,10 @@ public class ConnectionMaxAgeThread implements Runnable {
 					Thread.sleep(20L); // test slowly, this is not an operation that we're in a hurry to deal with (avoid CPU spikes)...
 				}
 			}  catch (Throwable e) {
-				if (this.scheduler.isShutdown()){
-					logger.debug("Shutting down connection max age thread.");
-				} else {
 					logger.error("Connection max age thread exception.", e);
-				}
 			}
 
 		} // throw it back on the queue
-
-		if (!this.scheduler.isShutdown()){
-			this.scheduler.schedule(this, nextCheckInMs, TimeUnit.MILLISECONDS);
-		}
 
 	}
 

--- a/bonecp/src/main/java/com/jolbox/bonecp/ConnectionTesterThread.java
+++ b/bonecp/src/main/java/com/jolbox/bonecp/ConnectionTesterThread.java
@@ -17,8 +17,6 @@
 package com.jolbox.bonecp;
 
 import java.sql.SQLException;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,8 +35,6 @@ public class ConnectionTesterThread implements Runnable {
 	private long idleMaxAgeInMs;
 	/** Partition being handled. */
 	private ConnectionPartition partition;
-	/** Scheduler handle. **/
-	private ScheduledExecutorService scheduler;
 	/** Handle to connection pool. */
 	private BoneCP pool;
 	/** If true, we're operating in a LIFO fashion. */ 
@@ -48,16 +44,14 @@ public class ConnectionTesterThread implements Runnable {
 
 	/** Constructor
 	 * @param connectionPartition partition to work on
-	 * @param scheduler Scheduler handler.
 	 * @param pool pool handle
 	 * @param idleMaxAgeInMs Threads older than this are killed off 
 	 * @param idleConnectionTestPeriodInMs Threads that are idle for more than this time are sent a keep-alive.
 	 * @param lifoMode if true, we're running under a lifo fashion.
 	 */
-	protected ConnectionTesterThread(ConnectionPartition connectionPartition, ScheduledExecutorService scheduler, 
+	protected ConnectionTesterThread(ConnectionPartition connectionPartition,
 			BoneCP pool, long idleMaxAgeInMs, long idleConnectionTestPeriodInMs, boolean lifoMode){
 		this.partition = connectionPartition;
-		this.scheduler = scheduler;
 		this.idleMaxAgeInMs = idleMaxAgeInMs;
 		this.idleConnectionTestPeriodInMs = idleConnectionTestPeriodInMs;
 		this.pool = pool;
@@ -138,13 +132,8 @@ public class ConnectionTesterThread implements Runnable {
 				// offset by a bit to avoid firing a lot for slightly offset connections
 //				logger.debug("Next check in "+nextCheckInMs);
 				
-				this.scheduler.schedule(this, nextCheckInMs, TimeUnit.MILLISECONDS);
 		} catch (Throwable e) {
-			if (this.scheduler.isShutdown()){
-				logger.debug("Shutting down connection tester thread.");
-			} else {
 				logger.error("Connection tester thread interrupted", e);
-			}
 		}
 	}
 


### PR DESCRIPTION
I didn't investigated why tasks was not executed with fixed delay one by one,but I think ScheduledExecutorService.scheduleAtFixedRate() is simple and powerful,and reliable.
