### PR TITLE
Posible fix for NPE while using CachedConnectionStrategy

### DIFF
--- a/bonecp/src/main/java/com/jolbox/bonecp/CachedConnectionStrategy.java
+++ b/bonecp/src/main/java/com/jolbox/bonecp/CachedConnectionStrategy.java
@@ -113,7 +113,7 @@ public class CachedConnectionStrategy extends AbstractConnectionStrategy {
 						if (!CachedConnectionStrategy.this.pool.poolShuttingDown){
 							logger.debug("Monitored thread is dead, closing off allocated connection.");
 						}
-						c.close();
+						c.internalClose();
 					} catch (SQLException e) {
 						e.printStackTrace();
 					}


### PR DESCRIPTION
In the CachedConnectionStrategy we should use internalClose to prevent BoneCP from returning null-connection handles.
