### PR TITLE
Include an SQL state when throwing an SQLException during checkClosed

### DIFF
--- a/bonecp/src/main/java/com/jolbox/bonecp/ConnectionHandle.java
+++ b/bonecp/src/main/java/com/jolbox/bonecp/ConnectionHandle.java
@@ -457,7 +457,7 @@ public class ConnectionHandle implements Connection,Serializable{
 	 */
 	private void checkClosed() throws SQLException {
 		if (this.logicallyClosed.get()) {
-			throw new SQLException("Connection is closed!");
+			throw new SQLException("Connection is closed!", "08003");
 		}
 	}
 


### PR DESCRIPTION
This patch includes an SQL error code, that provides a better indicator to
consumers to retry. Otherwise, the exception is too bland and matching on
the string is not the best kind of API.

More details here: http://jolbox.com/forum/viewtopic.php?f=3&t=582

Signed-off-by: Ken Barber ken@bob.sh
