### PR TITLE
update pom with SMC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
 
 	<scm>
 		<url>http://github.com/wwadge/bonecp</url>
-		<connection>scm:git:ssh://github.com/wwadge/bonecp.git</connection>
-		<developerConnection>scm:git:ssh://git@github.com/wwadge/bonecp.git</developerConnection>
+		<connection>scm:git:ssh://git@github.com:wwadge/bonecp.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com:wwadge/bonecp.git</developerConnection>
 	  <tag>HEAD</tag>
   </scm>
 


### PR DESCRIPTION
 upstream project maintainer of BoneCP has incorrectly specified the SCM within the POM.xml. He specifies connections as SSH but provided URL is http